### PR TITLE
Propagate props using <div/> using <pre/><code/>

### DIFF
--- a/src/optimized.jsx
+++ b/src/optimized.jsx
@@ -6,6 +6,7 @@ var Highlight = React.createClass({
   getDefaultProps: function () {
     return {
       innerHTML: false,
+      propsHTML: false,
       className: "",
       languages: []
     };
@@ -35,9 +36,13 @@ var Highlight = React.createClass({
   render: function () {
     if (this.props.innerHTML) {
       return <div dangerouslySetInnerHTML={{__html: this.props.children}} className={this.props.className || null}></div>;
-    } else {
-      return <pre><code className={this.props.className}>{this.props.children}</code></pre>;
     }
+
+    if(this.props.propsHTML) {
+      return <div className={this.props.className || null}>{this.props.children}</div>;
+    }
+
+    return <pre><code className={this.props.className}>{this.props.children}</code></pre>;
   }
 });
 


### PR DESCRIPTION
I'm using `ReactMarkdown` to parse markdown into html, but in this case I cannot use `innerHTML` flag, if I propagate props as usual it works like a charm, but it wraps into `<code>` block..

```jsx
<Highlight className={styles.component} languages={['ruby', 'javascript']} propsHTML={true}>
  <ReactMarkdown source={markdownContent} />
</Highlight>
```

Not sure, if is this the right solutions, but it works this way.