### PR TITLE
Add support for inline styling of pre and code elements

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -6,7 +6,9 @@ var Highlight = React.createClass({
   getDefaultProps: function () {
     return {
       innerHTML: false,
-      className: null
+      className: null,
+      codeStyle: null,
+      preStyle: null,
     };
   },
   componentDidMount: function () {
@@ -28,7 +30,7 @@ var Highlight = React.createClass({
     if (this.props.innerHTML) {
       return <div dangerouslySetInnerHTML={{__html: this.props.children}} className={this.props.className || null}></div>;
     } else {
-      return <pre><code className={this.props.className}>{this.props.children}</code></pre>;
+      return <pre style={this.props.preStyle}><code className={this.props.className} style={this.props.codeStyle}>{this.props.children}</code></pre>;
     }
   }
 });

--- a/test/highlight.test.jsx
+++ b/test/highlight.test.jsx
@@ -32,6 +32,24 @@ describe('highlight', function() {
     expect(ReactDOM.findDOMNode(text).textContent).toBe('Sometext');
   });
 
+  it('should accept a preStyle prop and apply the styles to the pre element', function() {
+    var preStyle = {backgroundColor: 'white'};
+    var text = ReactDOMServer.renderToStaticMarkup(
+        <Highlight preStyle={preStyle}>Some text</Highlight>
+      );
+
+    expect(text).toBe('<pre style="background-color:white;"><code>Some text</code></pre>');
+  });
+
+  it('should accept a codeStyle prop and apply the styles to the code element', function() {
+    var codeStyle = {backgroundColor: 'white'};
+    var text = ReactDOMServer.renderToStaticMarkup(
+        <Highlight codeStyle={codeStyle}>Some text</Highlight>
+      );
+
+    expect(text).toBe('<pre><code style="background-color:white;">Some text</code></pre>');
+  });
+
 });
 
 


### PR DESCRIPTION
Hey, this is just a small PR to add the ability to style the `pre` and `code` elements.
