### PR TITLE
use gulp-sass instead of gulp-ruby-sass

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,5 +1,5 @@
 var gulp = require('gulp');
-var sass = require('gulp-ruby-sass');
+var sass = require('gulp-sass');
 var webpack = require('webpack');
 var WebpackDevServer = require('webpack-dev-server');
 
@@ -9,15 +9,14 @@ gulp.task('copy', function () {
 });
 
 gulp.task('sass', function () {
-  return  gulp.src(['./docs/**/*.scss'])
-              .pipe(sass({ loadPath : ['bower_components', 'node_modules'],}))
-               .on('error', function (err) { console.log(err.message); })
-              .pipe(gulp.dest('./build'));
+    return gulp.src('./docs/**/*.scss')
+      .pipe(sass({ loadPath : ['bower_components', 'node_modules'],}).on('error', sass.logError))
+      .pipe(gulp.dest('./build'));
 });
 
 gulp.task('server', ['copy', 'sass'], function (callback) {
   var myConfig = require('./webpack.config.js');
-  
+
   var webpackCompiler = webpack(myConfig, function(err, stats) {
   });
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "eslint": "^3.19.0",
     "eslint-plugin-react": "^6.10.3",
     "gulp": "^3.9.1",
-    "gulp-ruby-sass": "^2.1.1",
+    "gulp-sass": "^3.0.0",
     "html-loader": "^0.4.5",
     "jasmine-core": "^2.5.2",
     "jsx-loader": "^0.13.2",


### PR DESCRIPTION
In order to make #40 work, I had a real issue with gulp-ruby-sass (I do not have ruby on my server ;) )

I think it will be easier for future PRs to avoid that ruby complexity, and it seems to work fine with `gulp-sass` directly