### PR TITLE
fix: include react / react-dom as peer dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,9 +27,7 @@
   },
   "homepage": "https://github.com/akiran/react-highlight",
   "dependencies": {
-    "highlight.js": "^9.11.0",
-    "react": "^15.5.4",
-    "react-dom": "^15.5.4"
+    "highlight.js": "^9.11.0"
   },
   "devDependencies": {
     "autoprefixer": "^6.7.7",
@@ -54,7 +52,13 @@
     "node-libs-browser": "^2.0.0",
     "phantomjs-prebuilt": "^2.1.14",
     "raw-loader": "^0.5.1",
+    "react": "^15.5.4",
+    "react-dom": "^15.5.4",
     "webpack": "^1.15.0",
     "webpack-dev-server": "^1.16.3"
+  },
+  "peerDependencies": {
+    "react": "^15.0.0-0 || ^16.0.0-0",
+    "react-dom": "^15.0.0-0 || ^16.0.0-0"
   }
 }


### PR DESCRIPTION
This should prevent multiple versions of react from being pulled and prevent the following error: 
https://fb.me/react-refs-must-have-owner