### PR TITLE
Remove highlight.js deprecation message

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,0 @@
-{
-  "presets": [
-    "env",
-    "react"
-  ]
-}

--- a/.eslintrc
+++ b/.eslintrc
@@ -3,13 +3,16 @@
     "no-extra-parens": 0,
     "react/jsx-uses-vars": 1,
     "global-strict": 1,
-    "quotes": [2, "single"],
+    "quotes": [
+      2,
+      "single"
+    ],
     "no-underscore-dangle": 0,
     "space-infix-ops": 0,
     "no-alert": 0
   },
   "ecmaFeatures": {
-    "jsx": true,
+    "jsx": true
   },
   "env": {
     "node": true,
@@ -19,6 +22,6 @@
   },
   "parser": "babel-eslint",
   "plugins": [
-      "react"
+    "react"
   ]
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -2,7 +2,7 @@
   "rules": {
     "no-extra-parens": 0,
     "react/jsx-uses-vars": 1,
-    "global-strict": 1,
+    "strict": 1,
     "quotes": [
       2,
       "single"
@@ -18,9 +18,9 @@
     "node": true,
     "browser": true,
     "es6": true,
-    "jasmine": true
+    "jest": true
   },
-  "parser": "babel-eslint",
+  "parser": "@babel/eslint-parser",
   "plugins": [
     "react"
   ]

--- a/babel.config.json
+++ b/babel.config.json
@@ -1,0 +1,6 @@
+{
+  "presets": [
+    "@babel/preset-env",
+    "@babel/preset-react"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/akiran/react-highlight",
   "dependencies": {
-    "highlight.js": "^10.5.0"
+    "highlight.js": "^10.7.2"
   },
   "devDependencies": {
     "autoprefixer": "^6.7.7",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "React component for syntax highlighting",
   "main": "index.js",
   "scripts": {
-    "prepublish": "babel ./src --out-dir ./lib --plugins=transform-class-properties,transform-react-jsx --presets=env",
+    "prepublish": "npx babel ./src --out-dir ./lib",
     "test": "BABEL_ENV=test jest"
   },
   "repository": {
@@ -28,36 +28,28 @@
     "highlight.js": "^10.7.2"
   },
   "devDependencies": {
-    "autoprefixer": "^6.7.7",
-    "babel-cli": "^6.26.0",
-    "babel-core": "^6.26.0",
-    "babel-eslint": "^6.1.2",
-    "babel-jest": "^22.4.3",
-    "babel-loader": "^7.1.2",
-    "babel-plugin-transform-class-properties": "^6.24.1",
-    "babel-plugin-transform-react-jsx": "^6.24.1",
-    "babel-preset-env": "^1.6.1",
-    "babel-preset-es2015": "^6.24.1",
-    "babel-preset-react": "^6.24.1",
-    "babel-preset-stage-0": "^6.24.1",
-    "eslint": "^3.19.0",
-    "eslint-plugin-react": "^6.10.3",
-    "html-loader": "^0.4.5",
-    "jest": "^22.4.2",
-    "jsx-loader": "^0.13.2",
-    "markdown-loader": "^2.0.0",
-    "multiline": "^1.0.2",
-    "node-libs-browser": "^2.0.0",
-    "raw-loader": "^0.5.1",
-    "react": "^15.5.4",
-    "react-dom": "^15.5.4",
-    "react-test-renderer": "^16.2.0",
-    "regenerator-runtime": "^0.11.1",
-    "webpack": "^3.6.0",
-    "webpack-dev-server": "^2.9.1"
+    "@babel/cli": "^7.14.3",
+    "@babel/core": "^7.14.3",
+    "@babel/eslint-parser": "^7.14.3",
+    "@babel/preset-env": "^7.14.2",
+    "@babel/preset-react": "^7.13.13",
+    "autoprefixer": "^10.2.6",
+    "babel-jest": "^27.0.1",
+    "eslint": "^7.27.0",
+    "eslint-plugin-react": "^7.23.2",
+    "jest": "^27.0.1",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2",
+    "react-test-renderer": "^17.0.2",
+    "regenerator-runtime": "^0.13.7"
   },
   "peerDependencies": {
     "react": "^15.0.0 || ^16.0.0 || ^17.0.0",
     "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0"
+  },
+  "jest": {
+    "transform": {
+      "^.+\\.[t|j]sx?$": "babel-jest"
+    }
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,7 @@ class Highlight extends React.Component {
         const nodes = this.el.querySelectorAll('pre code');
 
         for (let i = 0; i < nodes.length; i++) {
-            hljs.highlightBlock(nodes[i])
+            hljs.highlightElement(nodes[i]);
         }
     }
 

--- a/src/optimized.js
+++ b/src/optimized.js
@@ -23,7 +23,7 @@ class Highlight extends React.Component {
         });
 
         for (let i = 0; i < nodes.length; i++) {
-            hljs.highlightBlock(nodes[i])
+            hljs.highlightElement(nodes[i])
         }
     }
 

--- a/test/highlight.test.js
+++ b/test/highlight.test.js
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import Highlight from '../src'
 import ReactDOM from 'react-dom'
 import TestUtils from 'react-dom/test-utils'


### PR DESCRIPTION
According to [merged PR](https://github.com/highlightjs/highlight.js/pull/3003), `highlightBlock` API gets deprecated.